### PR TITLE
fix(workflows): Add /bin and /usr/bin to PATH to resolve spawn ps ENOENT

### DIFF
--- a/.github/workflows/auto-close-duplicates.yml
+++ b/.github/workflows/auto-close-duplicates.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Auto-close duplicate issues
         run: bun run scripts/auto-close-duplicates.ts
         env:
+          PATH: /bin:/usr/bin:$PATH
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/backfill-duplicate-comments.yml
+++ b/.github/workflows/backfill-duplicate-comments.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Backfill duplicate comments
         run: bun run scripts/backfill-duplicate-comments.ts
         env:
+          PATH: /bin:/usr/bin:$PATH
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DAYS_BACK: ${{ inputs.days_back }}
           DRY_RUN: ${{ inputs.dry_run }}


### PR DESCRIPTION
Some long-running scripts were failing with a `spawn ps ENOENT` error. This was happening because the `ps` command could not be found in the PATH of the child process.

This change fixes the issue by explicitly adding `/bin` and `/usr/bin` to the `PATH` environment variable in the relevant GitHub Actions workflow steps. This ensures that the `ps` command is available to the scripts.

## Resumo por Sourcery

Adiciona /bin e /usr/bin ao PATH nos fluxos de trabalho do GitHub Actions para etapas de script, a fim de garantir que o comando `ps` esteja disponível e evitar erros `spawn ps ENOENT`.

Correções de Bugs:
- Inclui /bin e /usr/bin no ambiente PATH para a etapa do fluxo de trabalho `auto-close-duplicates` para resolver o problema do comando `ps` ausente
- Inclui /bin e /usr/bin no ambiente PATH para a etapa do fluxo de trabalho `backfill-duplicate-comments` para resolver o problema do comando `ps` ausente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add /bin and /usr/bin to the PATH in GitHub Actions workflows for script steps to ensure the ps command is available and prevent spawn ps ENOENT errors

Bug Fixes:
- Include /bin and /usr/bin in the PATH environment for the auto-close-duplicates workflow step to resolve missing ps command
- Include /bin and /usr/bin in the PATH environment for the backfill-duplicate-comments workflow step to resolve missing ps command

</details>